### PR TITLE
Added AWS ChatBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you want to contribute, please read [CONTRIBUTING.md](./CONTRIBUTING.md).
 ## Services
 
 * [WorkflowCI](https://www.workflowci.com) – IFTTT for developers (freemium). Integrates with Slack, GitHub, CircleCI, Google Cloud Build.
+* [AWS ChatBot](https://aws.amazon.com/chatbot/) - an interactive agent to monitor and interact with AWS resources in  Slack 
 
 ## Frameworks and libraries
 


### PR DESCRIPTION
It's not a framework, rather a dedicated bot that pushes AWS information into a Slack channel.

Due diligence - I'm not connected to AWS in any way. I'm an IBMer who works with ChatOps and I've got a series of links I'd like to add over the next few days, some will be IBM-y and others (like this) will be 3rd party/generic.