### PR TITLE
Add Abbot to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ If you want to contribute, please read [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Services
 
+* [Abbot](https://ab.bot) – a hosted ChatOps bot, extendible in C#, Python, and JavaScript  (freemium). Integrates with Slack and Discord.
 * [AWS ChatBot](https://aws.amazon.com/chatbot/) - an interactive agent to monitor and interact with AWS resources in  Slack.
 
 ## Frameworks and libraries


### PR DESCRIPTION
Hi there, 

I work on [Abbot](https://ab.bot), which we are building as a spiritual successor to Hubot. We just opened our beta, and will always have a generous free tier. Abbot handles a lot of the annoying parts of running a bot, from hosting and platform compatibility to secrets management and scheduling events. It does a ton more as well. 

Please let me know if there's a better place to add it to the list!