### PR TITLE
Add Service marbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ If you want to contribute, please read [CONTRIBUTING.md](./CONTRIBUTING.md).
 ## Services
 
 * [AWS ChatBot](https://aws.amazon.com/chatbot/) - an interactive agent to monitor and interact with AWS resources in  Slack.
+* [marbot](https://marbot.io/) - configure AWS monitoring, receive alerts, and solve incidents in Slack or Microsoft Teams.
 
 ## Frameworks and libraries
 


### PR DESCRIPTION
marbot is an [alternative to AWS Chatbot](https://marbot.io/blog/aws-chatbot-vs-marbot.html) started in 2016 (long before AWS Chatbot was available). I would be happy to see it listed here.

Full disclosure: I'm one of the developers of marbot.